### PR TITLE
Use generic Iterable instead

### DIFF
--- a/src/awstanding/parameter_store.py
+++ b/src/awstanding/parameter_store.py
@@ -16,8 +16,7 @@ load_parameters(LOOKUP_DICT)
 
 """
 import os
-from typing import Union
-from collections.abc import Iterable
+from typing import Union, Iterable
 
 import boto3
 from boto3.exceptions import Boto3Error


### PR DESCRIPTION
Use generic typing.Iterable instead of collections.abc in order to fix TypeError in python 3.8

```Python 3.8.9 (default, Aug  3 2021, 19:21:54) 
[Clang 13.0.0 (clang-1300.0.29.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> 
>>> from awstanding.parameter_store import load_path
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "blah/venv/lib/python3.8/site-packages/awstanding/parameter_store.py", line 69, in <module>
    def load_path(*paths: Union[Iterable[str], str]) -> dict:
TypeError: 'ABCMeta' object is not subscriptable
```
